### PR TITLE
Add purchase step option

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -119,6 +119,30 @@ class Gateway extends AbstractGateway
     }
 
     /**
+     * Getter: purchase step.
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function getPurchaseStep()
+    {
+        return $this->getParameter('purchaseStep');
+    }
+
+    /**
+     * Setter: purchase step.
+     *
+     * @param $value
+     *
+     * @return $this
+     */
+    public function setPurchaseStep($value)
+    {
+        return $this->setParameter('purchaseStep', $value);
+    }
+
+    /**
      * Getter: coupon.
      *
      * @return string

--- a/src/Message/AbstractRequest.php
+++ b/src/Message/AbstractRequest.php
@@ -39,6 +39,16 @@ abstract class AbstractRequest extends BaseAbstractRequest
         return $this->setParameter('language', $value);
     }
 
+    public function getPurchaseStep()
+    {
+        return $this->getParameter('purchaseStep');
+    }
+
+    public function setPurchaseStep($value)
+    {
+        return $this->setParameter('purchaseStep', $value);
+    }
+
     public function getCoupon()
     {
         return $this->getParameter('coupon');

--- a/src/Message/PurchaseRequest.php
+++ b/src/Message/PurchaseRequest.php
@@ -29,6 +29,10 @@ class PurchaseRequest extends AbstractRequest
             $data['lang'] = $this->getLanguage();
         }
 
+        if ($this->getPurchaseStep()) {
+            $data['purchase_step'] = $this->getPurchaseStep();
+        }
+
         if ($this->getCoupon()) {
             $data['coupon'] = $this->getCoupon();
         }

--- a/tests/GatewayTest.php
+++ b/tests/GatewayTest.php
@@ -21,6 +21,7 @@ class GatewayTest extends GatewayTestCase
         $this->gateway->setTestMode(true);
         $this->gateway->setDemoMode(true);
         $this->gateway->setLanguage('fr');
+        $this->gateway->setPurchaseStep('payment-method');
         $this->gateway->setCoupon('BlackFriday');
         $this->gateway->setCart(array(
             array(
@@ -57,6 +58,7 @@ class GatewayTest extends GatewayTestCase
         $cart = $this->gateway->getCart();
         $this->assertSame('901290261', $this->gateway->getAccountNumber());
         $this->assertSame('MzBjODg5YTUtNzcwMS00N2NlLWFkODMtNzQ2YzllZWRjMzBj', $this->gateway->getSecretWord());
+        $this->assertSame('payment-method', $this->gateway->getPurchaseStep());
         $this->assertSame('BlackFriday', $this->gateway->getCoupon());
         $this->assertSame('fr', $this->gateway->getLanguage());
         $this->assertTrue($this->gateway->getTestMode());


### PR DESCRIPTION
Add one of the missing purchase parameters - `purchase_step`

Reference: https://www.2checkout.com/documentation/checkout/parameters