### PR TITLE
Avoid undefined indexes in notifications

### DIFF
--- a/src/Message/NotificationResponse.php
+++ b/src/Message/NotificationResponse.php
@@ -7,71 +7,77 @@ use Omnipay\Common\Message\AbstractResponse;
 
 class NotificationResponse extends AbstractResponse implements NotificationInterface
 {
-    /**
-     * Is the notification hash correct after validation?
-     */
-    public function isSuccessful()
-    {
-        // Validate the Hash
-        $hashSecretWord = isset($this->data['secretWord'])    ? $this->data['secretWord']    : ''; // Input your secret word
-        $hashSid        = isset($this->data['accountNumber']) ? $this->data['accountNumber'] : ''; // Input your seller ID (2Checkout account number)
-        $hashOrder      = isset($this->data['sale_id'])       ? $this->data['sale_id']       : '';
-        $hashInvoice    = isset($this->data['invoice_id'])    ? $this->data['invoice_id']    : '';
-	    $md5_hash       = isset($this->data['md5_hash'])      ? $this->data['md5_hash']      : '';
-        $StringToHash   = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
+	/**
+	 * Is the notification hash correct after validation?
+	 */
+	public function isSuccessful()
+	{
+		// Validate the Hash
+		$hashSecretWord = isset($this->data['secretWord'])    ? $this->data['secretWord']    : null; // Input your secret word
+		$hashSid        = isset($this->data['accountNumber']) ? $this->data['accountNumber'] : null; // Input your seller ID (2Checkout account number)
+		$hashOrder      = isset($this->data['sale_id'])       ? $this->data['sale_id']       : null;
+		$hashInvoice    = isset($this->data['invoice_id'])    ? $this->data['invoice_id']    : null;
+		$md5_hash       = isset($this->data['md5_hash'])      ? $this->data['md5_hash']      : null;
 		
-        return $StringToHash == $md5_hash;
-    }
+		// if no value has been posted, it has no way to be valid
+		if ($hashSecretWord === null || $hashSid === null || $hashOrder === null || $hashInvoice === null || $md5_hash === null) {
+			return false;
+		}
+		
+		$StringToHash = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
 
-    /**
-     * 2Checkout transaction reference.
-     *
-     * @return mixed
-     */
-    public function getTransactionReference()
-    {
-        return isset($this->data['sale_id']) ? $this->data['sale_id'] : '';
-    }
+		return (string)$StringToHash == (string)$md5_hash;
+	}
 
-    /**
-     * Order or transaction ID.
-     *
-     * @return mixed
-     */
-    public function getTransactionId()
-    {
-        return isset($this->data['vendor_order_id']) ? $this->data['vendor_order_id'] : '';
-    }
+	/**
+	 * 2Checkout transaction reference.
+	 *
+	 * @return mixed
+	 */
+	public function getTransactionReference()
+	{
+		return isset($this->data['sale_id']) ? $this->data['sale_id'] : null;
+	}
 
-    /**
-     * Indicate what type of 2Checkout notification this is.
-     *
-     * @return string
-     */
-    public function getNotificationType()
-    {
-        return isset($this->data['message_type']) ? $this->data['message_type'] : '';
-    }
+	/**
+	 * Order or transaction ID.
+	 *
+	 * @return mixed
+	 */
+	public function getTransactionId()
+	{
+		return isset($this->data['vendor_order_id']) ? $this->data['vendor_order_id'] : null;
+	}
 
-    /**
-     * Get transaction/notification status.
-     *
-     * SInce this is an IPN notification, we made this true.
-     *
-     * @return bool
-     */
-    public function getTransactionStatus()
-    {
-        return true;
-    }
+	/**
+	 * Indicate what type of 2Checkout notification this is.
+	 *
+	 * @return string
+	 */
+	public function getNotificationType()
+	{
+		return isset($this->data['message_type']) ? $this->data['message_type'] : null;
+	}
 
-    /**
-     * Notification response.
-     *
-     * @return mixed
-     */
-    public function getMessage()
-    {
-        return $this->data;
-    }
+	/**
+	 * Get transaction/notification status.
+	 *
+	 * SInce this is an IPN notification, we made this true.
+	 *
+	 * @return bool
+	 */
+	public function getTransactionStatus()
+	{
+		return true;
+	}
+
+	/**
+	 * Notification response.
+	 *
+	 * @return mixed
+	 */
+	public function getMessage()
+	{
+		return $this->data;
+	}
 }

--- a/src/Message/NotificationResponse.php
+++ b/src/Message/NotificationResponse.php
@@ -8,18 +8,19 @@ use Omnipay\Common\Message\AbstractResponse;
 class NotificationResponse extends AbstractResponse implements NotificationInterface
 {
     /**
-     * Is the notification harsh correct after validation?
+     * Is the notification hash correct after validation?
      */
     public function isSuccessful()
     {
-        # Validate the Hash
-        $hashSecretWord = $this->data['secretWord']; # Input your secret word
-        $hashSid = $this->data['accountNumber']; #Input your seller ID (2Checkout account number)
-        $hashOrder = $this->data['sale_id'];
-        $hashInvoice = $this->data['invoice_id'];
-        $StringToHash = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
-
-        return $StringToHash == $this->data['md5_hash'];
+        // Validate the Hash
+        $hashSecretWord = isset($this->data['secretWord'])    ? $this->data['secretWord']    : ''; // Input your secret word
+        $hashSid        = isset($this->data['accountNumber']) ? $this->data['accountNumber'] : ''; // Input your seller ID (2Checkout account number)
+        $hashOrder      = isset($this->data['sale_id'])       ? $this->data['sale_id']       : '';
+        $hashInvoice    = isset($this->data['invoice_id'])    ? $this->data['invoice_id']    : '';
+	    $md5_hash       = isset($this->data['md5_hash'])      ? $this->data['md5_hash']      : '';
+        $StringToHash   = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
+		
+        return $StringToHash == $md5_hash;
     }
 
     /**
@@ -29,7 +30,7 @@ class NotificationResponse extends AbstractResponse implements NotificationInter
      */
     public function getTransactionReference()
     {
-        return $this->data['sale_id'];
+        return isset($this->data['sale_id']) ? $this->data['sale_id'] : '';
     }
 
     /**
@@ -39,7 +40,7 @@ class NotificationResponse extends AbstractResponse implements NotificationInter
      */
     public function getTransactionId()
     {
-        return $this->data['vendor_order_id'];
+        return isset($this->data['vendor_order_id']) ? $this->data['vendor_order_id'] : '';
     }
 
     /**
@@ -49,7 +50,7 @@ class NotificationResponse extends AbstractResponse implements NotificationInter
      */
     public function getNotificationType()
     {
-        return $this->data['message_type'];
+        return isset($this->data['message_type']) ? $this->data['message_type'] : '';
     }
 
     /**

--- a/src/Message/NotificationResponse.php
+++ b/src/Message/NotificationResponse.php
@@ -7,77 +7,79 @@ use Omnipay\Common\Message\AbstractResponse;
 
 class NotificationResponse extends AbstractResponse implements NotificationInterface
 {
-	/**
+    /**
 	 * Is the notification hash correct after validation?
 	 */
-	public function isSuccessful()
-	{
-		// Validate the Hash
-		$hashSecretWord = isset($this->data['secretWord'])    ? $this->data['secretWord']    : null; // Input your secret word
-		$hashSid        = isset($this->data['accountNumber']) ? $this->data['accountNumber'] : null; // Input your seller ID (2Checkout account number)
-		$hashOrder      = isset($this->data['sale_id'])       ? $this->data['sale_id']       : null;
-		$hashInvoice    = isset($this->data['invoice_id'])    ? $this->data['invoice_id']    : null;
-		$md5_hash       = isset($this->data['md5_hash'])      ? $this->data['md5_hash']      : null;
-		
-		// if no value has been posted, it has no way to be valid
-		if ($hashSecretWord === null || $hashSid === null || $hashOrder === null || $hashInvoice === null || $md5_hash === null) {
-			return false;
-		}
-		
-		$StringToHash = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
+    public function isSuccessful()
+    {
+        // Validate the Hash
+        $hashSecretWord = isset($this->data['secretWord'])    ? $this->data['secretWord']    : null;
+        $hashSid        = isset($this->data['accountNumber']) ? $this->data['accountNumber'] : null;
+        $hashOrder      = isset($this->data['sale_id'])       ? $this->data['sale_id']       : null;
+        $hashInvoice    = isset($this->data['invoice_id'])    ? $this->data['invoice_id']    : null;
+        $md5_hash       = isset($this->data['md5_hash'])      ? $this->data['md5_hash']      : null;
 
-		return (string)$StringToHash == (string)$md5_hash;
-	}
+        // if no value has been posted, it has no way to be valid
+        if ($hashSecretWord === null || $hashSid === null ||
+            $hashOrder === null || $hashInvoice === null ||
+            $md5_hash === null) {
+            return false;
+        }
+        
+        $StringToHash = strtoupper(md5($hashOrder.$hashSid.$hashInvoice.$hashSecretWord));
+        
+        return (string)$StringToHash == (string)$md5_hash;
+    }
 
-	/**
-	 * 2Checkout transaction reference.
-	 *
-	 * @return mixed
-	 */
-	public function getTransactionReference()
-	{
-		return isset($this->data['sale_id']) ? $this->data['sale_id'] : null;
-	}
+    /**
+     * 2Checkout transaction reference.
+     *
+     * @return mixed
+     */
+    public function getTransactionReference()
+    {
+        return isset($this->data['sale_id']) ? $this->data['sale_id'] : null;
+    }
 
-	/**
-	 * Order or transaction ID.
-	 *
-	 * @return mixed
-	 */
-	public function getTransactionId()
-	{
-		return isset($this->data['vendor_order_id']) ? $this->data['vendor_order_id'] : null;
-	}
+    /**
+     * Order or transaction ID.
+     *
+     * @return mixed
+     */
+    public function getTransactionId()
+    {
+         return isset($this->data['vendor_order_id']) ? $this->data['vendor_order_id'] : null;
+    }
 
-	/**
-	 * Indicate what type of 2Checkout notification this is.
-	 *
-	 * @return string
-	 */
-	public function getNotificationType()
-	{
-		return isset($this->data['message_type']) ? $this->data['message_type'] : null;
-	}
+    /**
+     * Indicate what type of 2Checkout notification this is.
+     *
+     * @return string
+     */
+    public function getNotificationType()
+    {
+         return isset($this->data['message_type']) ? $this->data['message_type'] : null;
+    }
 
-	/**
-	 * Get transaction/notification status.
-	 *
-	 * SInce this is an IPN notification, we made this true.
-	 *
-	 * @return bool
-	 */
-	public function getTransactionStatus()
-	{
-		return true;
-	}
+    /**
+     * Get transaction/notification status.
+     *
+     * SInce this is an IPN notification, we made this true.
+     *
+     * @return bool
+     */
+    public function getTransactionStatus()
+    {
+        return true;
+    }
 
-	/**
-	 * Notification response.
-	 *
-	 * @return mixed
-	 */
-	public function getMessage()
-	{
-		return $this->data;
-	}
+    /**
+     * Notification response.
+     *
+     * @return mixed
+     */
+    public function getMessage()
+    {
+        return $this->data;
+    }
 }

--- a/tests/Message/NotificationResponseTest.php
+++ b/tests/Message/NotificationResponseTest.php
@@ -20,6 +20,7 @@ class NotificationResponseTest extends TestCase
         $this->assertTrue($response->getTransactionStatus());
         $this->assertSame($data, $response->getMessage());
     }
+    
     public function testResponsePass()
     {
         $data = $this->getMockHttpResponse('FraudChangeNotificationPass.txt')->json();
@@ -44,4 +45,16 @@ class NotificationResponseTest extends TestCase
 
         $this->assertTrue($response->getTransactionStatus());
     }
+
+	public function testResponseNoData()
+	{
+		$data = array();
+		$response = new NotificationResponse($this->getMockRequest(), $data);
+
+		$this->assertFalse($response->isSuccessful());
+		$this->assertSame(null, $response->getTransactionReference());
+		$this->assertSame(null, $response->getTransactionId());
+		$this->assertSame(null, $response->getNotificationType());
+		$this->assertTrue($response->getTransactionStatus());
+	}
 }


### PR DESCRIPTION
If you have a webhook waiting information, with code similar to :
``` php
/* parse the incoming request in a meaningful response */
$response = app()->paymentManager->getProvider('2checkout')->getGateway()->acceptNotification()->send();
```
And someone does a post request without any data, it will trigger warnings like `Undefined index: sale_id` because there is basically no check made to see if the given array keys do exist.

This pull request checks using `isset` to make sure the array keys do exist before trying to fetch their value. Initially i thought to set the values to empty strings if they are not set, but in my second commit i used `null` as it makes more sense in this context. I also included a test for it.  

Please keep in mind i am not familiar at all with how your library works internally, so please review the changes carefully.

Thank you.